### PR TITLE
Fix for the new version of moq.

### DIFF
--- a/pkg/cmd/edit/edit_suite_test.go
+++ b/pkg/cmd/edit/edit_suite_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Sed is a workaround for https://github.com/matryer/moq/issues/86.
-//go:generate bash -c "moq -pkg edit_test ../../../vendor/github.com/aws/aws-sdk-go/service/kms/kmsiface KMSAPI | sed -e $'/^import/ a \\\n\\\t\"github.com/aws/aws-sdk-go/service/kms/kmsiface\"' > zz_generated.mock_kmsiface_test.go"
+//go:generate bash -c "moq -pkg edit_test ../../../vendor/github.com/aws/aws-sdk-go/service/kms/kmsiface KMSAPI | sed 's|github.com/Ridecell/ridectl/vendor/||' > zz_generated.mock_kmsiface_test.go"
 func kmsMock() *KMSAPIMock {
 	return &KMSAPIMock{
 		DecryptFunc: func(in *kms.DecryptInput) (*kms.DecryptOutput, error) {


### PR DESCRIPTION
https://github.com/matryer/moq/pull/87 fixed the lack of import, but now it's the wrong import. Strip off the vendor path from imports (and anything else).