### PR TITLE
updating the cask command

### DIFF
--- a/pkg/cmd/doctor.go
+++ b/pkg/cmd/doctor.go
@@ -245,7 +245,7 @@ var doctorTestPostgresql = &doctorTest{
 var doctorTestGcloud = &doctorTest{
 	subject:  "Google Cloud CLI",
 	checkCmd: "gcloud",
-	fixCmd:   `brew cask install google-cloud-sdk`,
+	fixCmd:   `brew install --cask google-cloud-sdk`,
 }
 
 // Check for kubectl.


### PR DESCRIPTION
I had to re-install ridectl and ran into a minor issue. Looks like the command changed now. 
https://stackoverflow.com/questions/30413621/homebrew-cask-option-not-recognized

```
visu@Visus-MacBook-Pro:~/Work/summon-platform$ ridectl doctor --interactive
✅ Found $EDITOR Environment Variable
✅ Found Homebrew
✅ Found Homebrew Caskroom
✅ Found Latest version of ridectl
✅ Found Postgresql CLI
❌ Did not find Google Cloud CLI
Would you like to fix Google Cloud CLI (brew cask install google-cloud-sdk)? y
Error: Unknown command: cask
Error: exit status 1
Usage:
  ridectl doctor [flags]

Flags:
  -h, --help          help for doctor
  -i, --interactive   enable interactive mode

Global Flags:
      --kubeconfig string   (optional) absolute path to the kubeconfig file (default "/Users/visu/.kube/config")

exit status 1
visu@Visus-MacBook-Pro:~/Work/summon-platform$ brew cask install google-cloud-sdk
Error: Unknown command: cask

visu@Visus-MacBook-Pro:~/Work/summon-platform$ brew install --cask google-cloud-sdk
==> Tapping homebrew/cask
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask'...
Enter passphrase for key '/Users/visu/.ssh/id_ed25519':
remote: Enumerating objects: 590592, done.
```