### PR TITLE
Devops-2925 ridectl restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 `ridectl` is Ridecell's internal tool that enables employees access and ways to interact with SummonPlatform/Microservice instances. Employee's permissions are restricted to certain environments or features, depending on their role.
 
 Some key features are:
-1. Shelling into an instance (`shell`)
+1. Shelling into an instance (`shell`)\
     a. Summon-platform
     ```
     ridectl shell summontest-dev
@@ -13,7 +13,7 @@ Some key features are:
     ```
     ridectl shell svc-us-master-webhook-sms
     ```
-2. Shelling into an instance under the python environment (`pyshell`)
+2. Shelling into an instance under the python environment (`pyshell`)\
     a. Summon-platform
     ```
     ridectl pyshell summontest-dev
@@ -22,7 +22,7 @@ Some key features are:
     ```
     ridectl pyshell svc-us-master-webhook-sms
     ```
-3. Shelling into the instance's database (`dbshell`)
+3. Shelling into the instance's database (`dbshell`)\
     a. Summon-platform
     ```
     ridectl dbshell summontest-dev
@@ -31,12 +31,12 @@ Some key features are:
     ```
     ridectl dbshell svc-us-master-webhook-sms
     ```
-4. Obtaining dispatcher account password (`password`)
+4. Obtaining dispatcher account password (`password`)\
     a. Summon-platform
     ```
     ridectl password summontest-dev
     ```
-5. Restart migrations for a summon instance(`restart-migrations`)
+5. Restart migrations for a summon instance(`restart-migrations`)\
     a. Summon-platform
     ```
     ridectl restart-migrations summontest-dev

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Some key features are:
 3. shelling into the instance's database (`dbshell`)
 4. Obtaining dispatcher/support/reports account password (`password`)
 5. Restart migrations for a summon instance(`restart-migrations`)
-6. Create new summon-platform instance yml (`new`)
+6. Restart all pods of a certain type (web|celeryd|etc) (`restart`). Note: Only summon-platform is supported as of now
+7. Create new summon-platform instance yml (`new`)
 
 For a full list of functionalities, run `ridectl --help`
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Some key features are:
 4. Obtaining dispatcher/support/reports account password (`password`)
 5. Restart migrations for a summon instance(`restart-migrations`)
 6. Restart all pods of a certain type (web|celeryd|etc) (`restart`)
+e.g.
+    a. Summon-platform
+    `ridectl restart summontest-dev web`
+    b. Microservice
+    `ridectl restart svc-us-master-webhook-sms web`
 7. Create new summon-platform instance yml (`new`)
 
 For a full list of functionalities, run `ridectl --help`

--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ Some key features are:
 6. Restart all pods of a certain type (web|celeryd|etc) (`restart`)
 e.g.
     a. Summon-platform
-    `ridectl restart summontest-dev web`
+    ```
+        ridectl restart summontest-dev web
+    ```
     b. Microservice
-    `ridectl restart svc-us-master-webhook-sms web`
+    ```
+        ridectl restart svc-us-master-webhook-sms web
+    ```
 7. Create new summon-platform instance yml (`new`)
 
 For a full list of functionalities, run `ridectl --help`

--- a/README.md
+++ b/README.md
@@ -1,16 +1,47 @@
 # Ridectl
 
 ## Overview
-`ridectl` is Ridecell's internal tool that enables employees access and ways to interact with SummonPlatform instances. Employee's permissions are restricted to certain environments or features, depending on their role.
+`ridectl` is Ridecell's internal tool that enables employees access and ways to interact with SummonPlatform/Microservice instances. Employee's permissions are restricted to certain environments or features, depending on their role.
 
 Some key features are:
 1. shelling into an instance (`shell`)
+    a. Summon-platform
+    ```
+    ridectl shell summontest-dev
+    ```
+    b. Microservice
+    ```
+    ridectl shell svc-us-master-webhook-sms
+    ```
 2. shelling into an instance under the python environment (`pyshell`)
+    a. Summon-platform
+    ```
+    ridectl pyshell summontest-dev
+    ```
+    b. Microservice
+    ```
+    ridectl pyshell svc-us-master-webhook-sms
+    ```
 3. shelling into the instance's database (`dbshell`)
-4. Obtaining dispatcher/support/reports account password (`password`)
+    a. Summon-platform
+    ```
+    ridectl dbshell summontest-dev
+    ```
+    b. Microservice
+    ```
+    ridectl dbshell svc-us-master-webhook-sms
+    ```
+4. Obtaining dispatcher account password (`password`)
+    a. Summon-platform
+    ```
+    ridectl password summontest-dev
+    ```
 5. Restart migrations for a summon instance(`restart-migrations`)
+    a. Summon-platform
+    ```
+    ridectl restart-migrations summontest-dev
+    ```
 6. Restart all pods of a certain type (web|celeryd|etc) (`restart`)\
-e.g.\
     a. Summon-platform
     ```
     ridectl restart summontest-dev web
@@ -19,8 +50,6 @@ e.g.\
     ```
     ridectl restart svc-us-master-webhook-sms web
     ```
-7. Create new summon-platform instance yml (`new`)
-
 For a full list of functionalities, run `ridectl --help`
 
 ## Installing `ridectl`

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Some key features are:
 3. shelling into the instance's database (`dbshell`)
 4. Obtaining dispatcher/support/reports account password (`password`)
 5. Restart migrations for a summon instance(`restart-migrations`)
-6. Restart all pods of a certain type (web|celeryd|etc) (`restart`)
-e.g.
+6. Restart all pods of a certain type (web|celeryd|etc) (`restart`)\
+e.g.\
     a. Summon-platform
     ```
-        ridectl restart summontest-dev web
+    ridectl restart summontest-dev web
     ```
     b. Microservice
     ```
-        ridectl restart svc-us-master-webhook-sms web
+    ridectl restart svc-us-master-webhook-sms web
     ```
 7. Create new summon-platform instance yml (`new`)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Some key features are:
 3. shelling into the instance's database (`dbshell`)
 4. Obtaining dispatcher/support/reports account password (`password`)
 5. Restart migrations for a summon instance(`restart-migrations`)
-6. Restart all pods of a certain type (web|celeryd|etc) (`restart`). Note: Only summon-platform is supported as of now
+6. Restart all pods of a certain type (web|celeryd|etc) (`restart`)
 7. Create new summon-platform instance yml (`new`)
 
 For a full list of functionalities, run `ridectl --help`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 `ridectl` is Ridecell's internal tool that enables employees access and ways to interact with SummonPlatform/Microservice instances. Employee's permissions are restricted to certain environments or features, depending on their role.
 
 Some key features are:
-1. shelling into an instance (`shell`)
+1. Shelling into an instance (`shell`)
     a. Summon-platform
     ```
     ridectl shell summontest-dev
@@ -13,7 +13,7 @@ Some key features are:
     ```
     ridectl shell svc-us-master-webhook-sms
     ```
-2. shelling into an instance under the python environment (`pyshell`)
+2. Shelling into an instance under the python environment (`pyshell`)
     a. Summon-platform
     ```
     ridectl pyshell summontest-dev
@@ -22,7 +22,7 @@ Some key features are:
     ```
     ridectl pyshell svc-us-master-webhook-sms
     ```
-3. shelling into the instance's database (`dbshell`)
+3. Shelling into the instance's database (`dbshell`)
     a. Summon-platform
     ```
     ridectl dbshell summontest-dev

--- a/pkg/cmd/restart.go
+++ b/pkg/cmd/restart.go
@@ -40,6 +40,13 @@ func init() {
 	rootCmd.AddCommand(rollingRestartCmd)
 }
 
+/*
+We are using summon-operator to create deployments of summon-platform. So when we try to do rollout restart,
+it does not behave as expected because summon-operator is constantly watching the deployments and reconciles if anything changes.
+So when we do rollout restart k8s starts a new pod but it gets terminated immediately because summon-operator restarts.
+This becomes very tricky to handle in operator-itself. Hence we have implemented another way to do this
+Ref: https://ridecell.atlassian.net/browse/DEVOPS-2925
+*/
 var rollingRestartCmd = &cobra.Command{
 	Use:   "restart [flags] <cluster_name> <pod_type>",
 	Short: "Performs a rolling restart of pods.",

--- a/pkg/cmd/restart.go
+++ b/pkg/cmd/restart.go
@@ -84,7 +84,6 @@ var rollingRestartCmd = &cobra.Command{
 			podLabels["environment"] = target.Env
 			podLabels["region"] = target.Region
 			podLabels["role"] = args[1]
-			fmt.Printf("\n%+v\n", target)
 			deploymentName = fmt.Sprintf("%s-svc-%s-%s", target.Env, target.Namespace, args[1])
 		}
 


### PR DESCRIPTION
We are using summon-operator to create deployments of summon-platform. So when we try to do rollout restart, it does not behave as expected because summon-operator is constantly watching the deployments and reconciles if anything changes. So when we do rollout restart k8s starts a new pod but it gets terminated immediately because summon-operator restarts. This becomes very tricky to handle in operator-itself. Hence we have implemented another way to do this