### PR TITLE
DEVOPS-3537 Use ENV var instead of command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For a full list of functionalities, run `ridectl --help`
 
 ## Installing `ridectl`
 
-# Mac-os
+### Mac-os
 ```
 curl -L "https://github.com/Ridecell/ridectl/releases/latest/download/ridectl_macos.zip" -o ./ridectl_macos.zip
 unzip ridectl_macos.zip
@@ -62,10 +62,21 @@ chmod 0755 ridectl
 sudo cp ridectl /usr/local/bin/ridectl
 ```
 **Note:** When running `ridectl` for first time, Mac OS will not allow the binary to execute. So, to solve this issue, navigate to `System Prefrences` > `Security & Privacy` and in `General` section, allow `ridectl` to open.
-# Linux
+### Linux
 ```
 curl -L "https://github.com/Ridecell/ridectl/releases/latest/download/ridectl_linux.zip" -o ./ridectl_linux.zip
 unzip ridectl_linux.zip
 chmod 0755 ridectl
 sudo cp ridectl /usr/local/bin/ridectl
 ```
+
+## Environment variables
+
+List of environment variables used by `ridectl`:
+
+| Environment variable | Value | Description |
+| -------------------- | ------------- | ---------------- |
+| `RIDECTL_SKIP_UPGRADE` | `true\|false` | If set `true`, skips auto-upgrade of ridectl version; used in Github actions workflows |
+| `RIDECTL_SKIP_AWS_SSO` | `true\|false` | If set `true`, ridectl uses default AWS configuration instead of AWS SSO; used in Github actions workflows |
+| `EDITOR` | `vim`, `code`, etc | Sets editor's binary path for `ridectl edit` command |
+| `RIDECTL_TSH_CHECK` | `true\|false` | If set `false`, ridectl does not check for tsh login profile; used in Github actions workflows |

--- a/pkg/cmd/aws.go
+++ b/pkg/cmd/aws.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"regexp"
 	"strings"
 
@@ -31,8 +32,10 @@ import (
 func getAWSConfig(roleName, region string) (aws.Config, error) {
 	var cfg aws.Config
 
-	// If no-aws-sso flag is provided, do not use AWS SSO creds, instead load default configuration.
-	if noAWSSSO {
+	// If RIDECTL_SKIP_AWS_SSO env var is set to true, do not use AWS SSO creds, instead load default configuration.
+	noAWSSSO := os.Getenv("RIDECTL_SKIP_AWS_SSO")
+
+	if noAWSSSO == "true" {
 		// Load the Shared AWS Configuration (~/.aws/config)
 		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
 		if err != nil {

--- a/pkg/cmd/aws.go
+++ b/pkg/cmd/aws.go
@@ -48,6 +48,7 @@ func getAWSConfig(roleName, region string) (aws.Config, error) {
 	startUrl, accountId := utils.LoadAWSAccountInfo(ridectlConfigFile)
 	if startUrl == "" || accountId == "" {
 		updateAWSAccountInfo = true
+		pterm.Info.Println("If you don't know what to do, refer FAQs: https://docs.google.com/document/d/1v6lbH4NgN6rHBHpELWrcQ4CyqwVeSgeP/preview")
 
 		prompt := promptui.Prompt{
 			Label:    "Enter AWS SSO Start url",

--- a/pkg/cmd/aws.go
+++ b/pkg/cmd/aws.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 )
 
 func getAWSConfig(roleName, region string) (aws.Config, error) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -45,7 +45,6 @@ var (
 	versionFlag       bool
 	version           string
 	inCluster         bool
-	noAWSSSO          bool
 	ridectlHomeDir    string
 	ridectlConfigFile string
 )
@@ -73,7 +72,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&kubeconfigFlag, "kubeconfig", "", "(optional) absolute path to the kubeconfig file")
 	rootCmd.Flags().BoolVar(&versionFlag, "version", false, "--version")
 	rootCmd.PersistentFlags().BoolVar(&inCluster, "incluster", false, "(optional) use in cluster kube config")
-	rootCmd.PersistentFlags().BoolVar(&noAWSSSO, "no-aws-sso", false, "(optional) do not use AWS SSO for AWS authentication; use shared default configuration instead.")
 
 	// Display announcement banner if present
 	displayAnnouncementBanner()


### PR DESCRIPTION
In case of kubernetes-microservices workflows, it is better to use environment variable for ridectl to load default aws config.